### PR TITLE
Alexr00/rural owl

### DIFF
--- a/src/vs/editor/browser/services/treeSitter/treeSitterParserService.ts
+++ b/src/vs/editor/browser/services/treeSitter/treeSitterParserService.ts
@@ -212,6 +212,11 @@ export class TreeSitterParseResult implements IDisposable, ITreeSitterParseResul
 				return;
 			}
 		} while (!tree && !this._newEdits); // exit if there a new edits, as anhy parsing done while there are new edits is throw away work
+		if ((tree?.rootNode.childCount === 0) && model.getValueLength() > 0) {
+			// Something has gone horribly wrong
+			debugger;
+			this.tree = undefined;
+		}
 		this.sendParseTimeTelemetry(parseType, language, time, passes);
 		return tree;
 	}

--- a/src/vs/editor/browser/services/treeSitter/treeSitterParserService.ts
+++ b/src/vs/editor/browser/services/treeSitter/treeSitterParserService.ts
@@ -23,6 +23,7 @@ import { canASAR } from '../../../../base/common/amd.js';
 import { CancellationError, isCancellationError } from '../../../../base/common/errors.js';
 import { PromiseResult } from '../../../../base/common/observableInternal/promise.js';
 import { Position } from '../../../common/core/position.js';
+import { Range } from '../../../common/core/range.js';
 
 const EDITOR_TREESITTER_TELEMETRY = 'editor.experimental.treeSitterTelemetry';
 const MODULE_LOCATION_SUBPATH = `@vscode/tree-sitter-wasm/wasm`;
@@ -216,7 +217,16 @@ export class TreeSitterParseResult implements IDisposable, ITreeSitterParseResul
 	}
 
 	private _parseCallback(textModel: ITextModel, index: number): string | null {
-		return textModel.getTextBuffer().getNearestChunk(index);
+		const chunk = textModel.getTextBuffer().getNearestChunk(index);
+		const position = textModel.getPositionAt(index);
+		if (position.lineNumber < textModel.getLineCount()) {
+			const range = new Range(position.lineNumber, position.column, (position.lineNumber + 1), position.column);
+			const text = textModel.getValueInRange(range);
+			this._logService.debug(`TreeSitter: Requested chunk ${index} and got "${chunk.substring(0, 20)}" (length ${chunk.length}) for actual text "${text}"`);
+		} else {
+			this._logService.debug(`TreeSitter: Requested chunk ${index} and got "${chunk.substring(0, 20)}" (length ${chunk.length})`);
+		}
+		return chunk;
 	}
 
 	private sendParseTimeTelemetry(parseType: TelemetryParseType, languageId: string, time: number, passes: number): void {

--- a/src/vs/editor/browser/services/treeSitter/treeSitterParserService.ts
+++ b/src/vs/editor/browser/services/treeSitter/treeSitterParserService.ts
@@ -220,15 +220,12 @@ export class TreeSitterParseResult implements IDisposable, ITreeSitterParseResul
 				break;
 			}
 			if (isTreeEmpty()) {
-				// If the tree is empty then start over
+				// Something has gone horribly wrong
 				oldTree = undefined;
 				tree = undefined;
+				this.parser.reset();
 			}
 		} while (!tree && !this._newEdits); // exit if there a new edits, as anhy parsing done while there are new edits is throw away work
-		if (isTreeEmpty()) {
-			// Something has gone horribly wrong
-			tree = undefined;
-		}
 		this.sendParseTimeTelemetry(parseType, language, time, passes);
 		return tree;
 	}

--- a/src/vs/editor/browser/services/treeSitter/treeSitterParserService.ts
+++ b/src/vs/editor/browser/services/treeSitter/treeSitterParserService.ts
@@ -191,7 +191,7 @@ export class TreeSitterParseResult implements IDisposable, ITreeSitterParseResul
 	private async _parseAndYield(model: ITextModel, parseType: TelemetryParseType): Promise<Parser.Tree | undefined> {
 		const language = model.getLanguageId();
 		let tree: Parser.Tree | undefined;
-		const oldTree = this.tree?.copy();
+		let oldTree = this.tree?.copy();
 		let time: number = 0;
 		let passes: number = 0;
 		this._newEdits = false;
@@ -218,6 +218,11 @@ export class TreeSitterParseResult implements IDisposable, ITreeSitterParseResul
 
 			if (model.isDisposed() || this.isDisposed) {
 				break;
+			}
+			if (isTreeEmpty()) {
+				// If the tree is empty then start over
+				oldTree = undefined;
+				tree = undefined;
 			}
 		} while (!tree && !this._newEdits); // exit if there a new edits, as anhy parsing done while there are new edits is throw away work
 		if (isTreeEmpty()) {

--- a/src/vs/editor/browser/services/treeSitter/treeSitterParserService.ts
+++ b/src/vs/editor/browser/services/treeSitter/treeSitterParserService.ts
@@ -214,7 +214,6 @@ export class TreeSitterParseResult implements IDisposable, ITreeSitterParseResul
 		} while (!tree && !this._newEdits); // exit if there a new edits, as anhy parsing done while there are new edits is throw away work
 		if ((tree?.rootNode.childCount === 0) && model.getValueLength() > 0) {
 			// Something has gone horribly wrong
-			debugger;
 			this.tree = undefined;
 		}
 		this.sendParseTimeTelemetry(parseType, language, time, passes);


### PR DESCRIPTION
### **PR Type**
enhancement, bug fix


___

### **Description**
- Improved the calculation of the new end position after text changes by considering line breaks, enhancing accuracy.
- Added detailed logging to assist in debugging tree parsing, including logging of chunk requests and actual text.
- Implemented a check for empty parse trees and reset the parser when detected to handle parsing anomalies.
- Used a copy of the old tree for parsing to maintain consistency and reliability.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>treeSitterParserService.ts</strong><dd><code>Enhance tree parsing logic and add detailed logging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/vs/editor/browser/services/treeSitter/treeSitterParserService.ts

<li>Improved end position calculation for text changes.<br> <li> Added logging for debugging tree parsing issues.<br> <li> Implemented handling for empty parse trees by resetting the parser.<br> <li> Enhanced parse callback to log chunk requests and actual text.<br>


</details>


  </td>
  <td><a href="https://github.com/uristern123/vscode/pull/10/files#diff-57fe96385cfa45838fd3f40c7e745756d14de8201b073b8d46bd8bd8edb2e43e">+35/-5</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced text parsing logic to accurately handle multi-line changes.
	- Introduced safeguards for parser resets when the parsing tree is empty.
	- Improved logging for detailed insights into the parsing process.

- **Bug Fixes**
	- Resolved potential parsing errors by maintaining a copy of the parsing tree before edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->